### PR TITLE
Fix cameo gene deletion: evaluate the reaction's GPR, not a new empty one (#108)

### DIFF
--- a/src/fbc_curation/curator/curator.py
+++ b/src/fbc_curation/curator/curator.py
@@ -154,7 +154,7 @@ class Curator:
                 else:
                     # eval_gpr: True if the gene reaction rule is true with
                     # the given knockouts otherwise false
-                    gene_essential = not cobra.core.gene.GPR().eval(knockouts={gene.id})
+                    gene_essential = not tree.eval(knockouts={gene.id})
 
                 if gene_essential:
                     knockout_reactions[gene.id].append(reaction.id)


### PR DESCRIPTION
Fixes #108.

### The defect
In `Curator._knockout_reactions_for_genes` the reaction's GPR is parsed into `tree` and used to compute `gpr_genes`, but the essentiality test then evaluates a **freshly-constructed empty** `cobra.core.gene.GPR()` instead of `tree`:

```python
tree = cobra.core.gene.GPR().from_string(gpr)
gpr_genes = tree.genes
...
gene_essential = not cobra.core.gene.GPR().eval(knockouts={gene.id})   # empty GPR
```

An empty GPR's `.eval(knockouts=...)` returns `True` regardless of the knockouts, so `gene_essential` is always `False`. No reaction is ever knocked out, and the cameo curator reports the **wild-type objective for every gene** -- no gene is ever essential.

### Why it matters
For any model with genes, the gene-deletion section then disagrees between the cobrapy and cameo curators, so `FrogComparison.compare_reports` reports the model as **not reproducible even when it is**. Objective, FVA and reaction deletion are unaffected, so the failure looks isolated and puzzling. We hit this running FROG across a large model corpus.

### The fix
Evaluate the reaction's parsed GPR (one line):

```python
gene_essential = not tree.eval(knockouts={gene.id})
```

This is equivalent to `main`'s `eval_gpr(tree, knockouts={gene.id})`. **`main` is not affected** -- the regression arrived with the `eval_gpr` deprecation cleanup on `develop` (#107), and 0.3.2 appears to have been cut from `develop`.

### Verification
Bundled `e_coli_core`, cobra 0.31.1, Python 3.13 -- genes mapped to a knocked-out reaction:

| | genes mapped |
|---|---:|
| released 0.3.2 / current `develop` | **0** |
| with this change | **71** |

Spot-checked as biologically correct: `G_b0114`, `G_b0115`, `G_b0116` map to `R_PDH` / `R_AKGDH` (the pyruvate dehydrogenase complex). With the fix the cameo gene-deletion table matches cobrapy.

Happy to add a regression test asserting that at least one gene is essential in `e_coli_core` if you'd like it in the same PR.